### PR TITLE
do not die on rsync rc 24

### DIFF
--- a/bin/backup
+++ b/bin/backup
@@ -87,7 +87,7 @@ EOF
         $backup_root \
         $backup_host:$remote_path/${MODULE}/hourly.0;
 
-    [ $? == 0 ] || die "rsync failed"
+    [ $? == 0 -o $? == 24 ] || die "rsync failed"
 }
 
 


### PR DESCRIPTION
rc=24 stands for "Partial transfer due to vanished source files" (see man page), which might happen frequently on busy systems resulting in backups being never rotated. Happened to me quite often.

There are similar situations this PR not (yet) covers – but might be considered to – e.g. rsync fails because it cannot read a file on the source end. Thus, a single file might block rotation quite a while before noticed. So, if that's distinguishable, it should be ignored as well.